### PR TITLE
Show all events Leaflet - Frontend 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,17 +15,16 @@ function App() {
 
   //Makes API call when zipcode entered
   useEffect(() => {
-    if(currZip != null){
-      fetch("https://api.mobilize.us/v1/organizations/1316/events?timeslot_start=gte_now&zipcode=" + currZip)
+
+      fetch("https://gist.githubusercontent.com/mick/6c85985bbaee7419b6351501edd05de0/raw/f41482f485d3390516c390180c841c25b4213987/events.json")
       .then((res)=>res.json())
-      .then((data)=>setEvents(data['data']));
+      .then((data)=>setEvents(data));
 
       //Reset states on new zipcode
       setHoverEvent(null);
       setLocFilt(null);
 
-    }
-  }, [currZip]);
+  }, []);
 
   return (
     <div className="app">

--- a/src/App.js
+++ b/src/App.js
@@ -16,7 +16,7 @@ function App() {
   //Makes API call when zipcode entered
   useEffect(() => {
 
-      fetch("https://gist.githubusercontent.com/mick/6c85985bbaee7419b6351501edd05de0/raw/f41482f485d3390516c390180c841c25b4213987/events.json")
+      fetch("https://warren-events.s3.amazonaws.com/data/events.json")
       .then((res)=>res.json())
       .then((data)=>setEvents(data));
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -14,7 +14,6 @@ export function Map(props){
 
   //Called to set/unset location filter
   function locationFilter(event, set){
-    console.log(event)
 
     if(set){
       props.selectLoc({
@@ -109,27 +108,27 @@ export function Map(props){
     if(props.events != null){
 
       //Initiates map's focus at the first event (typically the closest to the provided zipcode) with a valid lat & long position
-      let first = 0;
-  		if (!('location' in props.events[first]) || !('location' in props.events[first]['location']) || !('latitude' in props.events[first]['location']['location'])) {
-  			first++;
-  		}
+      // let first = 0;
+  		// if (!('location' in props.events[first]) || !('location' in props.events[first]['location']) || !('latitude' in props.events[first]['location']['location'])) {
+  		// 	first++;
+  		// }
 
-      var lat = props.events[first]['location']['location']['latitude'];
-      var long = props.events[first]['location']['location']['longitude'];
+      // var lat = props.events[first]['location']['location']['latitude'];
+      // var long = props.events[first]['location']['location']['longitude'];
 
-      if(center[0] !== lat || center[0] !== long){
-        setCenter([lat, long]);
-        setNewCenter(true);
-      }
+      // if(center[0] !== lat || center[0] !== long){
+      //   setCenter([lat, long]);
+      //   setNewCenter(true);
+      // }
 
       var places = {};
 
       props.events.forEach(function(event, index) {
-
+        if (index > 500) return;
   			//If has longitude and latitute
   			if ('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) {
 
-  				//Creates string key for {places} dictionary
+          //Creates string key for {places} dictionary
   				let str = event['location']['location']['latitude'] + "&" + event['location']['location']['longitude'];
   				//Creates or adds to a location - adds HTML code for event list for that location
   				if (str in places) {
@@ -139,7 +138,7 @@ export function Map(props){
   				}
 
   			}
-  		});
+      });
       setLocations(places);
     }
 


### PR DESCRIPTION
Since we can fetch all events quickly on load with PR #27  Let's display them all on the map.  **This PR isnt meant to be merged**  Its just a quick pass at what map with all events looks like, and if leaflet will be able to handle this number of custom markers.

<img width="1364" alt="Screen Shot 2019-09-30 at 12 47 46 PM" src="https://user-images.githubusercontent.com/26278/65910917-89479680-e380-11e9-9fa7-efc3ac510a93.png">


It's great to see all the events across the Map.  But you'll notice if/when you run this the map is **SLOW**.  Leaflet + custom markers + a lot of events makes the interaction super slow, basically unusable.

I see we already need to figure out switching map tile providers in #25  This is another good reason to upgrade to mapbox-gl with that switch.

cc @jasonkalmeida 