### PR TITLE
uses mapbox-gl and shows all upcoming events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1310,6 +1310,68 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@mapbox/geojson-area": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-area/-/geojson-area-0.2.2.tgz",
+      "integrity": "sha1-GNeBSqNr8j+7zDefjiaiKSfevxA=",
+      "requires": {
+        "wgs84": "0.0.0"
+      }
+    },
+    "@mapbox/geojson-rewind": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.4.0.tgz",
+      "integrity": "sha512-b+1uPWBERW4Pet/969BNu61ZPDyH2ilIxBjJDFzxyS9TyszF9UrTQyYIl/G38clux3rtpAGGFSGTCSF/qR6UjA==",
+      "requires": {
+        "@mapbox/geojson-area": "0.2.2",
+        "concat-stream": "~1.6.0",
+        "minimist": "1.2.0",
+        "sharkdown": "^0.1.0"
+      }
+    },
+    "@mapbox/geojson-types": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
+      "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw=="
+    },
+    "@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha1-zlblOfg1UrWNENZy6k1vya3HsjQ="
+    },
+    "@mapbox/mapbox-gl-supported": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.4.1.tgz",
+      "integrity": "sha512-yyKza9S6z3ELKuf6w5n6VNUB0Osu6Z93RXPfMHLIlNWohu3KqxewLOq4lMXseYJ92GwkRAxd207Pr/Z98cwmvw=="
+    },
+    "@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI="
+    },
+    "@mapbox/tiny-sdf": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.1.1.tgz",
+      "integrity": "sha512-Ihn1nZcGIswJ5XGbgFAvVumOgWpvIjBX9jiRlIl46uQG9vJOF51ViBYHF95rEZupuyQbEmhLaDPLQlU7fUTsBg=="
+    },
+    "@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha1-FWUb1VOme4WB+zmIEMmK2Go0Uk4="
+    },
+    "@mapbox/vector-tile": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
+      "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
+      "requires": {
+        "@mapbox/point-geometry": "~0.1.0"
+      }
+    },
+    "@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -1891,6 +1953,11 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "ansicolors": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+      "integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
     },
     "anymatch": {
       "version": "2.0.0",
@@ -2872,6 +2939,15 @@
       "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
       "requires": {
         "rsvp": "^4.8.4"
+      }
+    },
+    "cardinal": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+      "integrity": "sha1-ylu2iltRG5D+k7ms6km97lwyv+I=",
+      "requires": {
+        "ansicolors": "~0.2.1",
+        "redeyed": "~0.4.0"
       }
     },
     "case-sensitive-paths-webpack-plugin": {
@@ -4039,6 +4115,11 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
+    "csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha1-s085HupNqPPpgjHizNjfnAQfFxs="
+    },
     "cssdb": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-4.4.0.tgz",
@@ -4582,6 +4663,11 @@
         "readable-stream": "^2.0.0",
         "stream-shift": "^1.0.0"
       }
+    },
+    "earcut": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.1.tgz",
+      "integrity": "sha512-5jIMi2RB3HtGPHcYd9Yyl0cczo84y+48lgKPxMijliNQaKAHEZJbdzLmKmdxG/mCdS/YD9DQ1gihL8mxzR0F9w=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -5990,6 +6076,11 @@
         "globule": "^1.0.0"
       }
     },
+    "geojson-vt": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
+      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -6065,6 +6156,11 @@
           }
         }
       }
+    },
+    "gl-matrix": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.1.0.tgz",
+      "integrity": "sha512-526NA+3EA+ztAQi0IZpSWiM0fyQXIp7IbRvfJ4wS/TjjQD0uv0fVybXwwqqSOlq33UckivI0yMDlVtboWm3k7A=="
     },
     "glob": {
       "version": "7.1.4",
@@ -6167,6 +6263,11 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+    },
+    "grid-index": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
+      "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA=="
     },
     "growly": {
       "version": "1.3.0",
@@ -8969,6 +9070,11 @@
         "object.assign": "^4.1.0"
       }
     },
+    "kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -9256,6 +9362,43 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "requires": {
         "object-visit": "^1.0.0"
+      }
+    },
+    "mapbox-gl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.1.tgz",
+      "integrity": "sha512-IF7b0LZd/caTiknPhm8DAcv7bhvOCXO6rsW18rmFxi8Vw0syJXKK8DLLabI5oiJXtUIgLe57XRgduQzAYrb4og==",
+      "requires": {
+        "@mapbox/geojson-rewind": "^0.4.0",
+        "@mapbox/geojson-types": "^1.0.2",
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/mapbox-gl-supported": "^1.4.0",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/tiny-sdf": "^1.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "@mapbox/whoots-js": "^3.1.0",
+        "csscolorparser": "~1.0.2",
+        "earcut": "^2.1.5",
+        "geojson-vt": "^3.2.1",
+        "gl-matrix": "^3.0.0",
+        "grid-index": "^1.1.0",
+        "minimist": "0.0.8",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^3.0.5",
+        "potpack": "^1.0.1",
+        "quickselect": "^2.0.0",
+        "rw": "^1.3.3",
+        "supercluster": "^6.0.1",
+        "tinyqueue": "^2.0.0",
+        "vt-pbf": "^3.1.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "md5.js": {
@@ -9551,6 +9694,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE="
+    },
+    "murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha1-sGJ44h/Gw3+lMTcysEEry2rhX1E="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -10265,6 +10413,15 @@
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
+      }
+    },
+    "pbf": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.0.tgz",
+      "integrity": "sha512-98Eh7rsJNJF/Im6XYMLaOW3cLnNyedlOd6hu3iWMD5I7FZGgpw8yN3vQBrmLbLodu7G784Irb9Qsv2yFrxSAGw==",
+      "requires": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
       }
     },
     "pbkdf2": {
@@ -11274,6 +11431,11 @@
         "uniq": "^1.0.1"
       }
     },
+    "potpack": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.1.tgz",
+      "integrity": "sha512-15vItUAbViaYrmaB/Pbw7z6qX2xENbFSTA7Ii4tgbPtasxm5v6ryKhKtL91tpWovDJzTiZqdwzhcFBCwiMVdVw=="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -11376,6 +11538,11 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.8.1"
       }
+    },
+    "protocol-buffers-schema": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.3.2.tgz",
+      "integrity": "sha512-Xdayp8sB/mU+sUV4G7ws8xtYMGdQnxbeIfLjyO9TZZRJdztBGhlmbI5x1qcY4TG5hBkIKGnc28i7nXxaugu88w=="
     },
     "proxy-addr": {
       "version": "2.0.5",
@@ -11483,6 +11650,11 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
+    "quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "raf": {
       "version": "3.4.1",
@@ -11871,6 +12043,21 @@
         "strip-indent": "^1.0.1"
       }
     },
+    "redeyed": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+      "integrity": "sha1-N+mQpvKyGyoRwuakj9QTVpjLqX8=",
+      "requires": {
+        "esprima": "~1.0.4"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        }
+      }
+    },
     "regenerate": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
@@ -12105,6 +12292,14 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
+    "resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "requires": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -12267,6 +12462,11 @@
       "requires": {
         "aproba": "^1.1.1"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q="
     },
     "rxjs": {
       "version": "6.5.2",
@@ -12603,6 +12803,23 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
+        }
+      }
+    },
+    "sharkdown": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sharkdown/-/sharkdown-0.1.1.tgz",
+      "integrity": "sha512-exwooSpmo5s45lrexgz6Q0rFQM574wYIX3iDZ7RLLqOb7IAoQZu9nxlZODU972g19sR69OIpKP2cpHTzU+PHIg==",
+      "requires": {
+        "cardinal": "~0.4.2",
+        "minimist": "0.0.5",
+        "split": "~0.2.10"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.5.tgz",
+          "integrity": "sha1-16oye87PUY+RBqxrjwA/o7zqhWY="
         }
       }
     },
@@ -12962,6 +13179,14 @@
         }
       }
     },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -13237,6 +13462,14 @@
             "uniq": "^1.0.1"
           }
         }
+      }
+    },
+    "supercluster": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-6.0.2.tgz",
+      "integrity": "sha512-aa0v2HURjBTOpbcknilcfxGDuArM8khklKSmZ/T8ZXL0BuRwb5aRw95lz+2bmWpFvCXDX/+FzqHxmg0TIaJErw==",
+      "requires": {
+        "kdbush": "^3.0.0"
       }
     },
     "supports-color": {
@@ -13522,6 +13755,11 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
+    },
+    "tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -13988,6 +14226,16 @@
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
+    "vt-pbf": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.1.tgz",
+      "integrity": "sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==",
+      "requires": {
+        "@mapbox/point-geometry": "0.1.0",
+        "@mapbox/vector-tile": "^1.3.1",
+        "pbf": "^3.0.5"
+      }
+    },
     "w3c-hr-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
@@ -14306,6 +14554,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+    },
+    "wgs84": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/wgs84/-/wgs84-0.0.0.tgz",
+      "integrity": "sha1-NP3FVZF7blfPKigu0ENxDASc3HY="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9115,11 +9115,6 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "leaflet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
-      "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
-    },
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
@@ -9365,9 +9360,9 @@
       }
     },
     "mapbox-gl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.3.1.tgz",
-      "integrity": "sha512-IF7b0LZd/caTiknPhm8DAcv7bhvOCXO6rsW18rmFxi8Vw0syJXKK8DLLabI5oiJXtUIgLe57XRgduQzAYrb4og==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mapbox-gl/-/mapbox-gl-1.4.0.tgz",
+      "integrity": "sha512-4nXRXanISou8oWLU7DH1ZetKvCJR9XtnMlQQ4Ia80wjghIHc5ljmAV/loNCI2UAGyuKINc7QcTiwUXrjE+Kv4w==",
       "requires": {
         "@mapbox/geojson-rewind": "^0.4.0",
         "@mapbox/geojson-types": "^1.0.2",
@@ -9379,7 +9374,7 @@
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
         "csscolorparser": "~1.0.2",
-        "earcut": "^2.1.5",
+        "earcut": "^2.2.0",
         "geojson-vt": "^3.2.1",
         "gl-matrix": "^3.0.0",
         "grid-index": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "dependencies": {
     "@types/lodash.sortby": "^4.7.6",
-    "leaflet": "^1.5.1",
     "lodash.groupby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
+    "mapbox-gl": "^1.3.1",
     "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "react": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@types/lodash.sortby": "^4.7.6",
     "lodash.groupby": "^4.6.0",
     "lodash.sortby": "^4.7.0",
-    "mapbox-gl": "^1.3.1",
+    "mapbox-gl": "^1.4.0",
     "moment": "^2.24.0",
     "node-sass": "^4.12.0",
     "react": "^16.9.0",

--- a/src/App.js
+++ b/src/App.js
@@ -5,13 +5,15 @@ import './App.scss';
 
 function App() {
   //List of events
-  const [events, setEvents] = useState(null);
+  const [events, setEvents] = useState([]);
   //Current zip code search - input by user
   const [currZip, setCurrZip] = useState(null);
   //Current event being hovered over
   const [hoverEvent, setHoverEvent] = useState(null);
   //Current selected location location filter
   const [locFilt, setLocFilt] = useState(null);
+
+  const [nearby, setNearby] = useState(null);
 
   //Makes API call when zipcode entered
   useEffect(() => {
@@ -28,7 +30,7 @@ function App() {
 
   return (
     <div className="app">
-      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt}/>
+      <SearchBar nearby={nearby} currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt}/>
       <Map currZip={currZip} events={events} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt}/>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ function App() {
   //Makes API call when zipcode entered
   useEffect(() => {
 
-      fetch("https://gist.githubusercontent.com/mick/6c85985bbaee7419b6351501edd05de0/raw/f41482f485d3390516c390180c841c25b4213987/events.json")
+      fetch("https://warren-events.s3.amazonaws.com/data/events.json")
       .then((res)=>res.json())
       .then((data)=>setEvents(data));
 

--- a/src/App.js
+++ b/src/App.js
@@ -8,18 +8,18 @@ function App() {
   const [events, setEvents] = useState([]);
   //Current zip code search - input by user
   const [currZip, setCurrZip] = useState(null);
-  //Current event being hovered over
-  const [hoverEvent, setHoverEvent] = useState(null);
-  //Current selected location filter
-  const [locFilt, setLocFilt] = useState(null);
+  //Current selected event
+  const [highlightedEvent, setHighlightedEvent] = useState({});
   //Events that are within the map viewport.  These should be shown in the list
-  const [inViewEvents, setInViewEvents] = useState([]);
+  const [inViewEvents, setInViewEvents] = useState({});
 
   // Load all of the events
   useEffect(() => {
       fetch("https://warren-events.s3.amazonaws.com/data/events.json")
       .then((res)=>res.json())
-      .then((data)=>setEvents(data));
+      .then((data)=>{
+        setEvents(data)
+      });
   }, []);
 
   useEffect(() => {
@@ -30,20 +30,19 @@ function App() {
     .then(res => {
       if (res.data && res.data.length > 0){
         let event = res.data[0]
-        setLocFilt(event.location.location.longitude +'&'+ event.location.location.latitude)
+        setHighlightedEvent({id: event.id, center:true})
       }
 
     })
 
     // Reset states on new zipcode
-    setHoverEvent(null);
-    setLocFilt(null);
+    setHighlightedEvent({});
   }, [currZip])
 
   return (
     <div className="app">
-      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} inViewEvents={inViewEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt}/>
-      <Map currZip={currZip} events={events} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt} inViewEvents={(keys) => setInViewEvents(keys)}/>
+      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} inViewEvents={inViewEvents} updatedHover={(newHover) => setHighlightedEvent(newHover)} highlightedEvent={highlightedEvent}/>
+      <Map events={events} selectEvent={(newLoc) => setHighlightedEvent(newLoc)} highlightedEvent={highlightedEvent} inViewEvents={(keys) => setInViewEvents(keys)}/>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -15,17 +15,16 @@ function App() {
 
   //Makes API call when zipcode entered
   useEffect(() => {
-    if(currZip != null){
-      fetch("https://api.mobilize.us/v1/organizations/1316/events?timeslot_start=gte_now&zipcode=" + currZip)
+
+      fetch("https://gist.githubusercontent.com/mick/6c85985bbaee7419b6351501edd05de0/raw/f41482f485d3390516c390180c841c25b4213987/events.json")
       .then((res)=>res.json())
-      .then((data)=>setEvents(data['data']));
+      .then((data)=>setEvents(data));
 
       //Reset states on new zipcode
       setHoverEvent(null);
       setLocFilt(null);
 
-    }
-  }, [currZip]);
+  }, []);
 
   return (
     <div className="app">

--- a/src/App.js
+++ b/src/App.js
@@ -8,9 +8,13 @@ function App() {
   const [events, setEvents] = useState([]);
   //Current zip code search - input by user
   const [currZip, setCurrZip] = useState(null);
-  //Current selected event
+  //Current highlighted event (hovered in the list)
   const [highlightedEvent, setHighlightedEvent] = useState({});
-  //Events that are within the map viewport.  These should be shown in the list
+  //Used to filter by location, since there may be more than 1 event at a location.
+  //It's a string in the format lng+'&'+lat
+  const [locationFilter, setLocationFilter] = useState(null)
+  //Events that are within the map viewport.  These should be shown in the list.
+  // This is a object keyed by eventid and used to filter the `events` object.
   const [inViewEvents, setInViewEvents] = useState({});
 
   // Load all of the events
@@ -30,19 +34,22 @@ function App() {
     .then(res => {
       if (res.data && res.data.length > 0){
         let event = res.data[0]
+
         setHighlightedEvent({id: event.id, center:[event.location.location.longitude, event.location.location.latitude]})
       }
-
-    })
+    });
 
     // Reset states on new zipcode
+    setInViewEvents({});
     setHighlightedEvent({});
+    setLocationFilter(null);
+
   }, [currZip])
 
   return (
     <div className="app">
-      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} inViewEvents={inViewEvents} updatedHover={(newHover) => setHighlightedEvent(newHover)} highlightedEvent={highlightedEvent}/>
-      <Map events={events} selectEvent={(newLoc) => setHighlightedEvent(newLoc)} highlightedEvent={highlightedEvent} inViewEvents={(keys) => setInViewEvents(keys)}/>
+      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} inViewEvents={inViewEvents} updatedHover={(newHover) => setHighlightedEvent(newHover)} locationFilter={locationFilter}/>
+      <Map events={events} setLocationFilter={(locKey) => setLocationFilter(locKey)} highlightedEvent={highlightedEvent} inViewEvents={(keys) => setInViewEvents(keys)} locationFilter={locationFilter}/>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -10,28 +10,40 @@ function App() {
   const [currZip, setCurrZip] = useState(null);
   //Current event being hovered over
   const [hoverEvent, setHoverEvent] = useState(null);
-  //Current selected location location filter
+  //Current selected location filter
   const [locFilt, setLocFilt] = useState(null);
+  //Events that are within the map viewport.  These should be shown in the list
+  const [inViewEvents, setInViewEvents] = useState([]);
 
-  const [nearby, setNearby] = useState(null);
-
-  //Makes API call when zipcode entered
+  // Load all of the events
   useEffect(() => {
-
       fetch("https://warren-events.s3.amazonaws.com/data/events.json")
       .then((res)=>res.json())
       .then((data)=>setEvents(data));
-
-      //Reset states on new zipcode
-      setHoverEvent(null);
-      setLocFilt(null);
-
   }, []);
+
+  useEffect(() => {
+    // Use the mobilizemaerica api to look up zipcode to nearest event.
+    if(currZip == null) return;
+    fetch("https://api.mobilize.us/v1/organizations/1316/events?timeslot_start=gte_now&zipcode=" + currZip)
+    .then((res)=>res.json())
+    .then(res => {
+      if (res.data && res.data.length > 0){
+        let event = res.data[0]
+        setLocFilt(event.location.location.longitude +'&'+ event.location.location.latitude)
+      }
+
+    })
+
+    // Reset states on new zipcode
+    setHoverEvent(null);
+    setLocFilt(null);
+  }, [currZip])
 
   return (
     <div className="app">
-      <SearchBar nearby={nearby} currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt}/>
-      <Map currZip={currZip} events={events} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt}/>
+      <SearchBar currZip={currZip} updateZip={(newZip) => setCurrZip(newZip)} events={events} inViewEvents={inViewEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt}/>
+      <Map currZip={currZip} events={events} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt} inViewEvents={(keys) => setInViewEvents(keys)}/>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,7 @@ function App() {
     .then(res => {
       if (res.data && res.data.length > 0){
         let event = res.data[0]
-        setHighlightedEvent({id: event.id, center:true})
+        setHighlightedEvent({id: event.id, center:[event.location.location.longitude, event.location.location.latitude]})
       }
 
     })

--- a/src/App.scss
+++ b/src/App.scss
@@ -116,3 +116,11 @@ input[type="number"]::-webkit-inner-spin-button {
 input[type="number"] {
     -moz-appearance: textfield;
 }
+
+.marker {
+  background-image: url('img/w-marker-icon-2x.png');
+  background-size: cover;
+  width: 25px;
+  height: 41px;
+  cursor: pointer;
+}

--- a/src/App.scss
+++ b/src/App.scss
@@ -76,10 +76,6 @@ html, body, #root, .app {
     text-transform: uppercase;
   }
 
-  :hover{
-    color: white;
-  }
-
   li{
     list-style-type: none;
     padding-left: 10%;
@@ -97,8 +93,9 @@ html, body, #root, .app {
 
   }
 
-  li:hover{
+  li.event:hover{
     background-color: #232444;
+    color: white;
 
     .eventRSVP{
       visibility: visible;

--- a/src/App.scss
+++ b/src/App.scss
@@ -61,7 +61,8 @@ html, body, #root, .app {
 
 .eventList{
   background-color: white;
-  height: 500px;
+  max-height: 500px;
+  min-height: 250px;
   overflow:hidden;
   overflow-y:scroll;
   margin-bottom: 0px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -101,6 +101,16 @@ html, body, #root, .app {
       visibility: visible;
     }
   }
+  li.highlighted{
+    background-color: #232444;
+    color: white;
+
+    .eventRSVP{
+      visibility: visible;
+    }
+  }
+
+
 
 }
 
@@ -112,12 +122,4 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 input[type="number"] {
     -moz-appearance: textfield;
-}
-
-.marker {
-  background-image: url('img/w-marker-icon-2x.png');
-  background-size: cover;
-  width: 25px;
-  height: 41px;
-  cursor: pointer;
 }

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react';
+import React from 'react';
 import moment from 'moment';
 import groupBy from 'lodash.groupby';
 import sortBy from 'lodash.sortby';
@@ -54,7 +54,7 @@ export function EventList(props) {
   if (props.locationFilter) {
     visableEvents = props.events.filter(event => {
         event.locationKey = event.location.location.longitude + '&' + event.location.location.latitude;
-        return (props.locationFilter == event.locationKey);
+        return (props.locationFilter === event.locationKey);
     })
   } else {
     // Filter based on the events that are currently in view.

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -52,9 +52,13 @@ export function EventList(props) {
   if (!props.locFilt && !props.nearBy) {
 
   }
+  // Filter based on the events that are currently in view.
+  var inViewEvents = props.events.filter(event => {
+    var locKey = event['location']['location']['longitude'] + '&' + event['location']['location']['latitude'];
+    return props.inViewEvents.indexOf(locKey) >= 0
+  })
 
-
-  const listEvents = props.events.map((event, i) => {
+  const listEvents = inViewEvents.map((event, i) => {
 
     // Normalize Mobilize's time formatting into
     // easy-to-use moments
@@ -67,13 +71,6 @@ export function EventList(props) {
       }
     })
 
-    //Location filter
-    var locKey = event['location']['location']['longitude'] + '&' + event['location']['location']['latitude'];
-
-    if(props.locFilt && locKey !== props.locFilt) {
-      return(null);
-    }
-
     return (
       <a href={event['browser_url']}
         className="eventCard"
@@ -82,7 +79,7 @@ export function EventList(props) {
         coord={('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) ? "" + event['location']['location']['longitude'] + "&" + event['location']['location']['latitude'] : ""}
         onMouseEnter={(event) => { props.updatedHover(event['currentTarget'].getAttribute('coord')) }}
         onMouseLeave={(event) => { props.updatedHover(null) }}>
-        <li>
+        <li className="event">
           <div>
             <h3>{event['title']}</h3>
             <p><strong>{event['location']['venue']}</strong> in <strong>{event['location']['locality']}</strong></p>
@@ -91,9 +88,14 @@ export function EventList(props) {
           </div>
         </li>
       </a>
-
     )
   });
+
+  listEvents.push((<div className="eventCard" key="noevent"><li>
+    <div>
+      <p><strong>Don't see an event near you? </strong><br /><a href="https://events.elizabethwarren.com/?is_virtual=true">Join a virtual event</a> or <a href="https://events.elizabethwarren.com/event/create/">host your own event!</a></p>
+    </div>
+  </li></div>))
 
   return (
     <ul className="eventList">{listEvents}</ul>

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -21,7 +21,7 @@ function EventTimes(props) {
   )
 
   let sortedDates = Object.keys(sortedTimesByDate).sort();
-  
+
   const dateRowFactory = (date) => {
     let times = sortedTimesByDate[date];
     let dayStr = times[0].start.format('ddd M/D')
@@ -49,7 +49,12 @@ function EventTimes(props) {
 }
 
 export function EventList(props) {
-  const listEvents = props.events.map((event) => {
+  if (!props.locFilt && !props.nearBy) {
+
+  }
+
+
+  const listEvents = props.events.map((event, i) => {
 
     // Normalize Mobilize's time formatting into
     // easy-to-use moments
@@ -63,23 +68,19 @@ export function EventList(props) {
     })
 
     //Location filter
-    if(props.locFilt != null){
-      if('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']){
-        if(event['location']['location']['latitude'] !== props.locFilt['lat'] || event['location']['location']['longitude'] != props.locFilt['lng']){
-          return(null);
-        }
-      } else {
-        return(null);
-      }
+    var locKey = event['location']['location']['longitude'] + '&' + event['location']['location']['latitude'];
+
+    if(props.locFilt && locKey !== props.locFilt) {
+      return(null);
     }
 
     return (
-      <a href={event['browser_url']} 
-        className="eventCard" 
-        target="_blank" 
-        key={event['id']} 
-        coord={('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) ? "" + event['location']['location']['latitude'] + "&" + event['location']['location']['longitude'] : ""} 
-        onMouseEnter={(event) => { props.updatedHover(event['currentTarget'].getAttribute('coord')) }} 
+      <a href={event['browser_url']}
+        className="eventCard"
+        target="_blank"
+        key={event['id']}
+        coord={('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) ? "" + event['location']['location']['longitude'] + "&" + event['location']['location']['latitude'] : ""}
+        onMouseEnter={(event) => { props.updatedHover(event['currentTarget'].getAttribute('coord')) }}
         onMouseLeave={(event) => { props.updatedHover(null) }}>
         <li>
           <div>

--- a/src/Map.js
+++ b/src/Map.js
@@ -14,7 +14,6 @@ export function Map(props){
 
   //Called to set/unset location filter
   function locationFilter(event, set){
-    console.log(event)
 
     if(set){
       props.selectLoc({
@@ -109,27 +108,27 @@ export function Map(props){
     if(props.events != null){
 
       //Initiates map's focus at the first event (typically the closest to the provided zipcode) with a valid lat & long position
-      let first = 0;
-  		if (!('location' in props.events[first]) || !('location' in props.events[first]['location']) || !('latitude' in props.events[first]['location']['location'])) {
-  			first++;
-  		}
+      // let first = 0;
+  		// if (!('location' in props.events[first]) || !('location' in props.events[first]['location']) || !('latitude' in props.events[first]['location']['location'])) {
+  		// 	first++;
+  		// }
 
-      var lat = props.events[first]['location']['location']['latitude'];
-      var long = props.events[first]['location']['location']['longitude'];
+      // var lat = props.events[first]['location']['location']['latitude'];
+      // var long = props.events[first]['location']['location']['longitude'];
 
-      if(center[0] !== lat || center[0] !== long){
-        setCenter([lat, long]);
-        setNewCenter(true);
-      }
+      // if(center[0] !== lat || center[0] !== long){
+      //   setCenter([lat, long]);
+      //   setNewCenter(true);
+      // }
 
       var places = {};
 
       props.events.forEach(function(event, index) {
-
+        if (index > 500) return;
   			//If has longitude and latitute
   			if ('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) {
 
-  				//Creates string key for {places} dictionary
+          //Creates string key for {places} dictionary
   				let str = event['location']['location']['latitude'] + "&" + event['location']['location']['longitude'];
   				//Creates or adds to a location - adds HTML code for event list for that location
   				if (str in places) {
@@ -139,7 +138,7 @@ export function Map(props){
   				}
 
   			}
-  		});
+      });
       setLocations(places);
     }
 

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -18,7 +18,7 @@ export function SearchBar(props){
 
   var eventlist = [];
   if (props.locFilt !== null || props.nearby !== null) {
-    eventlist = (<EventList events={props.events} inViewEvents={props.inViewEvents} highlightedEvent={props.highlightedEvent} updatedHover={(item) => props.updatedHover(item)}/>)
+    eventlist = (<EventList events={props.events} inViewEvents={props.inViewEvents} locationFilter={props.locationFilter} updatedHover={(item) => props.updatedHover(item)}/>)
   }
 
   return(

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -17,14 +17,18 @@ export function SearchBar(props){
     props.updateZip(input)
   }
 
+  var eventlist = [];
+  console.log(props)
+  if (props.locFilt !== null || props.nearby !== null) {
+    eventlist = (<EventList events={props.events} locFilt={props.locFilt} updatedHover={(item) => props.updatedHover(item)}/>)
+  }
+
   return(
-    <div className={props.events != null ? "searchBar activeList" : "searchBar"}>
+    <div className={(props.locFilt !== null || props.nearby !== null) ? "searchBar activeList" : "searchBar"}>
       <form onSubmit= {onSubmit} id = "zipForm">
         <input type="text" id="zipInput" value={input} onChange={onlySetNumbers} placeholder="ZIP" required minLength="5" maxLength="5"></input>
       </form>
-      {props.events !== null &&
-        <EventList events={props.events} locFilt={props.locFilt} updatedHover={(item) => props.updatedHover(item)}/>
-      }
+      { eventlist }
     </div>
   );
 }

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -18,7 +18,7 @@ export function SearchBar(props){
 
   var eventlist = [];
   if (props.locFilt !== null || props.nearby !== null) {
-    eventlist = (<EventList events={props.events} inViewEvents={props.inViewEvents} locFilt={props.locFilt} updatedHover={(item) => props.updatedHover(item)}/>)
+    eventlist = (<EventList events={props.events} inViewEvents={props.inViewEvents} highlightedEvent={props.highlightedEvent} updatedHover={(item) => props.updatedHover(item)}/>)
   }
 
   return(

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -8,7 +8,6 @@ export function SearchBar(props){
   function onlySetNumbers(event){
     let baseValue = event.target.value;
     let replacedVal = baseValue.replace(/\D*/g, '')
-    console.log(`baseValue: ${baseValue}, replacedVal: ${replacedVal}`);
     setInput(replacedVal)
   }
 
@@ -18,9 +17,8 @@ export function SearchBar(props){
   }
 
   var eventlist = [];
-  console.log(props)
   if (props.locFilt !== null || props.nearby !== null) {
-    eventlist = (<EventList events={props.events} locFilt={props.locFilt} updatedHover={(item) => props.updatedHover(item)}/>)
+    eventlist = (<EventList events={props.events} inViewEvents={props.inViewEvents} locFilt={props.locFilt} updatedHover={(item) => props.updatedHover(item)}/>)
   }
 
   return(


### PR DESCRIPTION
Mapbox gl allows for client side rendering of map data, which with a lot of custom markers allows for better performance over leaflet.

This PR relies on the pre-fetched bundle of events in #27.  This does change a bit of the map / marker logic.  There is a gh-pages deployed version here: https://mick.github.io/eventmap/


<img width="1373" alt="Screen Shot 2019-09-30 at 1 19 22 PM" src="https://user-images.githubusercontent.com/26278/65913555-fe1ccf80-e384-11e9-81e7-3090e761909e.png">

<img width="1367" alt="Screen Shot 2019-09-30 at 1 19 39 PM" src="https://user-images.githubusercontent.com/26278/65913574-037a1a00-e385-11e9-891a-4ae334684b48.png">

TODO
- [x] handle zipcode entry (center on zipcode or on nearest event to that zipcode?)

cc @jasonkalmeida @jlev