### PR TITLE
Fred mueller map not underneath

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6261,9 +6261,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,8 @@ const queryString = require('query-string');
  * 
  */
 
-const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+// const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+const deviceIsMobile = true;        // HACK to allow easy mocking of isMobile for testing/debugging
 
 function App() {
 
@@ -122,7 +123,8 @@ function App() {
   //      code just operates on the list of events passed to it.
 
   return (
-    <div className="app">
+    /* <div className="app"> */ /* frm: original code */
+    <div className={deviceIsMobile ? "app appIsMobile" : "app appIsDesktop"}>
       <SearchBar currZip={currZip} currRange={currRange} currEventKind={currEventKind} updateZip={(newZip) => setCurrZip(newZip)} updateRange={(newRange) => setCurrRange(newRange)} updateEventKind={(newEventKind) => setCurrEventKind(newEventKind)} events={filteredEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt} deviceIsMobile={deviceIsMobile}/>
       {events === null && currZip == null &&
         <div id="startLoad">
@@ -130,10 +132,10 @@ function App() {
           <h3 id="searchCTA">Enter your zipcode to find events near you!</h3>
         </div>
       }
+      <Map currZip={currZip} events={filteredEvents} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt}/>
       {filteredEvents !== null && deviceIsMobile &&
         <MobileList events={filteredEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt} cardIndex={cardIndex} updateCardIndex={(update) => setCardIndex(update)}/>
       }
-      <Map currZip={currZip} events={filteredEvents} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt}/>
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,8 @@ const queryString = require('query-string');
  * 
  */
 
-const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+// const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+const deviceIsMobile = true;
 
 function App() {
 

--- a/src/App.js
+++ b/src/App.js
@@ -36,8 +36,7 @@ const queryString = require('query-string');
  * 
  */
 
-// const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
-const deviceIsMobile = true;        // HACK to allow easy mocking of isMobile for testing/debugging
+const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
 
 function App() {
 

--- a/src/App.js
+++ b/src/App.js
@@ -37,7 +37,7 @@ const queryString = require('query-string');
  */
 
 // const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
-const deviceIsMobile = true;
+const deviceIsMobile = true;        // HACK to allow easy mocking of isMobile for testing/debugging
 
 function App() {
 
@@ -95,19 +95,31 @@ function App() {
     }
   }, [currZip, currRange]);
 
-  // Filters the events when there are new events from the API or when user changes filtering criteria
+  /* 
+   * Filters the events when there are new events from the API or 
+   * when the user changes filtering criteria
+   */
   useEffect(() => {
+
      if (!events){
-         return setFilteredEvents(null);
+         setCardIndex(null);             // no events, hence no valid cardIndex
+         setFilteredEvents(null);        // no events, hence no filtered events
+         return;
      }
 
+     setCardIndex(0);   // reset to the first event in the list
+
+     // if ALLEVENTS then return everything, otherwise filter on the current kind of event
      setFilteredEvents(events.filter((event) => {
          return ((currEventKind === 'ALLEVENTS') || (currEventKind === event['event_type']));
      }));
    }, [events, currEventKind]);
    
 
-  // If the cardIndex changes, reset the event whose marker is highlighted, by calling setHoverEvent()
+  /* 
+   * If the cardIndex changes, then reset the event whose 
+   * marker is highlighted, by calling setHoverEvent()
+   */
   useEffect(() => {
     if (deviceIsMobile && filteredEvents != null) {
       setHoverEvent(
@@ -123,7 +135,6 @@ function App() {
   //      code just operates on the list of events passed to it.
 
   return (
-    /* <div className="app"> */ /* frm: original code */
     <div className={deviceIsMobile ? "app appIsMobile" : "app appIsDesktop"}>
       <SearchBar currZip={currZip} currRange={currRange} currEventKind={currEventKind} updateZip={(newZip) => setCurrZip(newZip)} updateRange={(newRange) => setCurrRange(newRange)} updateEventKind={(newEventKind) => setCurrEventKind(newEventKind)} events={filteredEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt} deviceIsMobile={deviceIsMobile}/>
       {events === null && currZip == null &&

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,7 +2,7 @@
 
   height: 100vh;                /* frm: added for new UI */
   display: grid;                /* frm: added for new UI */
-  grid-template-columns: minmax(30%, 300px) minmax(70%,100%);            /* frm: added for new UI */
+  grid-template-columns: minmax(30%, 300px) minmax(70%, 100%);            /* frm: added for new UI */
 
   #map{
     height: 100vh;    /* frm: changed from % to vh */
@@ -77,7 +77,7 @@ html, body, #root, .app {
   /* padding-top: 2%; */         /* frm: commented out for new UI */
   /* padding-bottom: 2%; */      /* frm: commented out for new UI */
   background-color: #232444;
-  max-width: 300px;
+  /* max-width: 300px; */       /* frm: commented out for new UI */
   /* width: 32%; */             /* frm: commented out for new UI */
   /* position: fixed; */        /* frm: commented out for new UI */
   /* left: 2%; */               /* frm: commented out for new UI */

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,4 +1,9 @@
 .app{
+
+  height: 100vh;                /* frm: added for new UI */
+  diaplay: grid;                /* frm: added for new UI */
+  grid-template-columns: 200px auto;            /* frm: added for new UI */
+
   #map{
     height: 100%;
     z-index: 9;
@@ -39,7 +44,7 @@
           height: 10vw;
         }
       }
-    }
+    } 
     #secondLine{
       font-size: 20vh;
       color: white;
@@ -69,17 +74,21 @@ html, body, #root, .app {
 }
 
 .searchBar{
-  padding-top: 2%;
-  padding-bottom: 2%;
+  /* padding-top: 2%; */         /* frm: commented out for new UI */
+  /* padding-bottom: 2%; */      /* frm: commented out for new UI */
   background-color: #232444;
   //width: 300px;
   width: 32%;
-  position: fixed;
-  left: 2%;
-  top: 2%;
+  /* position: fixed; */        /* frm: commented oiut for new UI */
+  /* left: 2%; */               /* frm: commented out for new UI */
+  /* top: 2%; */               /* frm: commented out for new UI */
   z-index:11;
-  box-shadow: 10px 10px 5px rgba(0, 0, 0, .3);
+  /* box-shadow: 10px 10px 5px rgba(0, 0, 0, .3); */  /* frm: commented out for new UI */
 
+  height: 100vh;                /* frm: added for new UI */
+  display: grid;                /* frm: added for new UI */
+  grid-template-rows: auto auto;                /* frm: added for new UI */
+  grid-gap: 0;          /* frm: added for new UI */
 }
 
 .mobileSearch {

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,13 +1,51 @@
-.app{
+/* frm: I added classes to distinguish between desktop and 
+ *      mobile cases - appIsDesktop and appIsMobile.  This
+ *      allowed me to set up the grid differently for the
+ *      two cases.  For desktop, the app has a left panel
+ *      containing the search bar with the map on the
+ *      right.  For mobile, there is just a single column
+ *      withy three rows (search, map, mobile-list-of-events).
+ */
 
-  height: 100vh;                /* frm: added for new UI */
-  display: grid;                /* frm: added for new UI */
+.appIsDesktop {
+  display: grid;                /* frm: added for new map layout UI */
   grid-template-columns: minmax(180px,30%) auto;
 
   #map{
     height: 100vh;    /* frm: changed from % to vh */
     z-index: 9;
   }
+
+}
+
+.appIsMobile {
+  display: grid;                /* frm: added for new map layout UI */
+  grid-template-rows: min-content auto min-content;
+
+  #map{
+    /* height: 100vh; */   /* frm: don't need height for mobile */
+    z-index: 9;                 /* frm: not sure z-index does anything for mobile */
+  }
+
+}
+
+/* frm: I added a <div class="mobileNavWrapper> around the mobile 
+ *      previous, rsvp, next buttons in order to get the positioning 
+ *      of the buttons to work out.  There is probably a way to do it 
+ *      without resorting to creating their own container, but I 
+ *      didn't know how to do it.  In any event, the only reason for
+ *      this <div> is to get the positioning of the buttons
+ *      to be left, center, right.
+ */
+
+.mobileNavWrapper {
+  position: relative;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.app{
+  height: 100vh;                /* frm: added for new map layout UI */
 
   #startLoad{
     position: fixed;
@@ -74,22 +112,31 @@ html, body, #root, .app {
 }
 
 .searchBar{
-  /* padding-top: 2%; */         /* frm: commented out for new UI */
-  /* padding-bottom: 2%; */      /* frm: commented out for new UI */
+  /* padding-top: 2%; */        /* frm: commented out for new map layout UI */
+  /* padding-bottom: 2%; */     /* frm: commented out for new map layout UI */
   background-color: #232444;
-  /* max-width: 300px; */       /* frm: commented out for new UI */
-  /* width: 32%; */             /* frm: commented out for new UI */
-  /* position: fixed; */        /* frm: commented out for new UI */
-  /* left: 2%; */               /* frm: commented out for new UI */
-  /* top: 2%; */               /* frm: commented out for new UI */
-  z-index:11;
-  /* box-shadow: 10px 10px 5px rgba(0, 0, 0, .3); */  /* frm: commented out for new UI */
-  box-shadow: 10px 0px 5px rgba(0, 0, 0, .3);   /* frm: experiment to separate searchbar from map */
+  /* max-width: 300px; */       /* frm: commented out for new map layout UI */
+  /* width: 32%; */             /* frm: commented out for new map layout UI */
+  /* position: fixed; */        /* frm: commented out for new map layout UI */
+  /* left: 2%; */               /* frm: commented out for new map layout UI */
+  /* top: 2%; */                /* frm: commented out for new map layout UI */
+  z-index:11;                   /* frm: not sure we need z-index anymore */
+  box-shadow: 10px 0px 5px rgba(0, 0, 0, .3);   /* frm: don't need bottom shadow for new map layout UI */
 
-  height: 100vh;                /* frm: added for new UI */
-  display: grid;                /* frm: added for new UI */
-  grid-template-rows: auto auto;                /* frm: added for new UI */
-  grid-gap: 0;          /* frm: added for new UI */
+}
+
+/* frm: Added class, desktopSearch, as an analog for the preexisting mobileSearch
+ *      so that I could have a different layout (using grid) for the deesktop
+ *      use case.  In this case the search bar has two rows that take up all 
+ *      of the vertical space.
+ */
+
+.desktopSearch {
+  /* For desktop, we want two rows */
+  height: 100vh;                        /* frm: added for new map layout UI */
+  display: grid;                        /* frm: added for new map layout UI */
+  grid-template-rows: auto auto;        /* frm: added for new map layout UI */
+  grid-gap: 0;                          /* frm: added for new map layout UI */
 }
 
 .mobileSearch {
@@ -281,7 +328,7 @@ html, body, #root, .app {
 
 .eventList{
   background-color: white;
-  /* height: 500px; */          /* frm: commented out for new UI */
+  /* height: 500px; */          /* frm: commented out for new map layout UI */
   overflow:hidden;
   overflow-y:scroll;
   margin-bottom: 0px;
@@ -344,11 +391,12 @@ html, body, #root, .app {
   margin: none;
   font-size:calc(10px + 1vw);   /* frm: changed from 12px to 10px to conserve whitespace */
   touch-action: manipulation;
+  position: relative;           /* frm: added so children can be positioned absolutely */
   .eventCard{
 
     text-decoration: none;
     color: #232444;
-    position: fixed;
+    /* position: fixed; */      /* frm: commented out for new map layout UI */
     z-index: 10;
     bottom: 10%;        /* changed from 13% to 10% */
     background-color: white;
@@ -384,7 +432,7 @@ html, body, #root, .app {
   }
 
   button{
-    position: fixed;
+    position: absolute;         /* frm: changed for new map layout UI */
     bottom: 3%;         /* frm: changed from 5% to 3% */
     z-index: 10;
     background-color: #232444;

--- a/src/App.scss
+++ b/src/App.scss
@@ -9,7 +9,7 @@
 
 .appIsDesktop {
   display: grid;                /* frm: added for new map layout UI */
-  grid-template-columns: minmax(180px,30%) auto;
+  grid-template-columns: minmax(180px,300px) auto;
 
   #map{
     height: 100vh;    /* frm: changed from % to vh */
@@ -24,6 +24,10 @@
 
   #map{
     /* height: 100vh; */   /* frm: don't need height for mobile */
+    /* ??? frm: 
+     *      Actually I might need the height for mobile.  The documentation
+     *      for leaflet says that there needs to be a defined height.
+     */
     z-index: 9;                 /* frm: not sure z-index does anything for mobile */
   }
 
@@ -38,10 +42,20 @@
  *      to be left, center, right.
  */
 
+/* frm: commented this out for now - replaced with code immediately below
+ *
 .mobileNavWrapper {
-  position: relative;
+  ** position: relative; **   ** frm: using flex below means I don't need relative position **
   margin-top: 5px;
   margin-bottom: 5px;
+}
+ *
+ */
+
+.mobileNavWrapper {     /* frm: new code based on flex */
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
 }
 
 .app{
@@ -405,7 +419,7 @@ html, body, #root, .app {
     max-height: 30vh;
     min-height: 10vh;  /* changed from 20vh to 10vh to conserve whitespace */
     box-shadow: 1px 2px 5px rgba(0, 0, 0, .3);
-    border: 1px solid #232444;
+    /* border: 1px solid #232444; */ /* frm: removed as part of new layout UI */
 
     h3{
       margin-top: 10px;  /* frm: smaller for mobile to conserve whitespace */
@@ -421,7 +435,7 @@ html, body, #root, .app {
 
       padding-left: 5%;
       padding-right: 5%;
-      padding-bottom: 2%;  /* frm: added this to make sure we had some whitespace at bottom (after reducing min-height of .eventCard */
+      padding-bottom: 1%;
 
       .eventRSVP{
         display: none;  /* frm: changed from visibility: hidden to display: none to conserve whitespace */
@@ -432,7 +446,7 @@ html, body, #root, .app {
   }
 
   button{
-    position: absolute;         /* frm: changed for new map layout UI */
+    /* position: absolute; */         /* frm: changed for new map layout UI */
     bottom: 3%;         /* frm: changed from 5% to 3% */
     z-index: 10;
     background-color: #232444;
@@ -444,18 +458,19 @@ html, body, #root, .app {
 
   }
   #mobileRSVP{
-    left: 35%;
-    width: 30vw;
+    /* left: 35%; */ /* frm: commented out trying to get flex to work */
+    /* width: 30vw; */ /* frm: commented out because I now have it flex its width */
+    flex: 1;
     a{
       text-decoration: none;
       color:white;
     }
   }
   #leftIndex{
-    left: 25px;
+    /* left: 25px; */ /* frm: commented out trying to get flex to work */
   }
   #rightIndex{
-    right: 25px;
+    /* right: 25px; */ /* frm: commented out trying to get flex to work */
   }
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -84,6 +84,7 @@ html, body, #root, .app {
   /* top: 2%; */               /* frm: commented out for new UI */
   z-index:11;
   /* box-shadow: 10px 10px 5px rgba(0, 0, 0, .3); */  /* frm: commented out for new UI */
+  box-shadow: 10px 0px 5px rgba(0, 0, 0, .3);   /* frm: experiment to separate searchbar from map */
 
   height: 100vh;                /* frm: added for new UI */
   display: grid;                /* frm: added for new UI */

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,7 +2,7 @@
 
   height: 100vh;                /* frm: added for new UI */
   display: grid;                /* frm: added for new UI */
-  grid-template-columns: 300px auto;            /* frm: added for new UI */
+  grid-template-columns: minmax(30%, 300px) minmax(70%,100%);            /* frm: added for new UI */
 
   #map{
     height: 100vh;    /* frm: changed from % to vh */
@@ -77,7 +77,7 @@ html, body, #root, .app {
   /* padding-top: 2%; */         /* frm: commented out for new UI */
   /* padding-bottom: 2%; */      /* frm: commented out for new UI */
   background-color: #232444;
-  //width: 300px;
+  max-width: 300px;
   /* width: 32%; */             /* frm: commented out for new UI */
   /* position: fixed; */        /* frm: commented out for new UI */
   /* left: 2%; */               /* frm: commented out for new UI */

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,11 +1,11 @@
 .app{
 
   height: 100vh;                /* frm: added for new UI */
-  diaplay: grid;                /* frm: added for new UI */
-  grid-template-columns: 200px auto;            /* frm: added for new UI */
+  display: grid;                /* frm: added for new UI */
+  grid-template-columns: 300px auto;            /* frm: added for new UI */
 
   #map{
-    height: 100%;
+    height: 100vh;    /* frm: changed from % to vh */
     z-index: 9;
   }
 
@@ -78,8 +78,8 @@ html, body, #root, .app {
   /* padding-bottom: 2%; */      /* frm: commented out for new UI */
   background-color: #232444;
   //width: 300px;
-  width: 32%;
-  /* position: fixed; */        /* frm: commented oiut for new UI */
+  /* width: 32%; */             /* frm: commented out for new UI */
+  /* position: fixed; */        /* frm: commented out for new UI */
   /* left: 2%; */               /* frm: commented out for new UI */
   /* top: 2%; */               /* frm: commented out for new UI */
   z-index:11;
@@ -131,7 +131,7 @@ html, body, #root, .app {
   align-items: flex-end;
   justify-content: center;
   padding-left: 5%;
-  padding-right: 7%;
+  padding-right: 5%;    /* frm: changed from 7% to 5% */
   padding-top: 5%;
   padding-bottom: 5%;
 
@@ -232,7 +232,7 @@ html, body, #root, .app {
   font-size: 16px;
   background-color: #f5f5f5;
   border: none;
-  padding: 0px 20px 0px 5px;
+  padding: 0px 5px 0px 5px;    /* frm: changed right-pad from 20px to 5px */
   appearance: none;
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -280,7 +280,7 @@ html, body, #root, .app {
 
 .eventList{
   background-color: white;
-  height: 500px;
+  /* height: 500px; */          /* frm: commented out for new UI */
   overflow:hidden;
   overflow-y:scroll;
   margin-bottom: 0px;

--- a/src/App.scss
+++ b/src/App.scss
@@ -2,7 +2,7 @@
 
   height: 100vh;                /* frm: added for new UI */
   display: grid;                /* frm: added for new UI */
-  grid-template-columns: minmax(30%, 300px) minmax(70%, 100%);            /* frm: added for new UI */
+  grid-template-columns: minmax(180px,30%) auto;
 
   #map{
     height: 100vh;    /* frm: changed from % to vh */

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,65 +1,51 @@
-/* frm: I added classes to distinguish between desktop and 
- *      mobile cases - appIsDesktop and appIsMobile.  This
- *      allowed me to set up the grid differently for the
- *      two cases.  For desktop, the app has a left panel
- *      containing the search bar with the map on the
- *      right.  For mobile, there is just a single column
- *      withy three rows (search, map, mobile-list-of-events).
+/* 
+ *
+ * The app uses a tiled layout that is different for desktop
+ * vs. mobile.  
+ *
+ * On desktop, there are two columns: the left
+ * column contains the search criteria <div> above a 
+ * scrolling list of events that match the search criteria.
+ * The width of the first column is constrained.  The right 
+ * column contains the map and it grows/shrinks to use up
+ * all of the remaining available space.
+ *
+ * On mobile, there is a single column that contains (in 
+ * order from top to bottom): the search criteria then
+ * the map and then an area where the event details are 
+ * provided along with buttons (previous, Info/RSVP, next).
+ *
+ * As you will see, we use CSS grid to implement this layout.
+ *
+ * To distinguish between the desktop and mobile cases, there
+ * is a class defined for each case: "appIsDesktop" and 
+ * "appIsMobile".
+ *
  */
 
 .appIsDesktop {
-  display: grid;                /* frm: added for new map layout UI */
+  display: grid;    /* on desktop use a two column grid layout - right column grows/shrinks */
   grid-template-columns: minmax(180px,300px) auto;
 
   #map{
-    height: 100vh;    /* frm: changed from % to vh */
+    height: 100vh;
     z-index: 9;
   }
 
 }
 
 .appIsMobile {
-  display: grid;                /* frm: added for new map layout UI */
+  display: grid;    /* on mobile use a row grid with three rows: search, map, card & nav */
   grid-template-rows: min-content auto min-content;
 
   #map{
-    /* height: 100vh; */   /* frm: don't need height for mobile */
-    /* ??? frm: 
-     *      Actually I might need the height for mobile.  The documentation
-     *      for leaflet says that there needs to be a defined height.
-     */
     z-index: 9;                 /* frm: not sure z-index does anything for mobile */
   }
 
 }
 
-/* frm: I added a <div class="mobileNavWrapper> around the mobile 
- *      previous, rsvp, next buttons in order to get the positioning 
- *      of the buttons to work out.  There is probably a way to do it 
- *      without resorting to creating their own container, but I 
- *      didn't know how to do it.  In any event, the only reason for
- *      this <div> is to get the positioning of the buttons
- *      to be left, center, right.
- */
-
-/* frm: commented this out for now - replaced with code immediately below
- *
-.mobileNavWrapper {
-  ** position: relative; **   ** frm: using flex below means I don't need relative position **
-  margin-top: 5px;
-  margin-bottom: 5px;
-}
- *
- */
-
-.mobileNavWrapper {     /* frm: new code based on flex */
-  display: flex;
-  flex-direction: row;
-  justify-content: space-around;
-}
-
 .app{
-  height: 100vh;                /* frm: added for new map layout UI */
+  height: 100vh;                
 
   #startLoad{
     position: fixed;
@@ -126,31 +112,17 @@ html, body, #root, .app {
 }
 
 .searchBar{
-  /* padding-top: 2%; */        /* frm: commented out for new map layout UI */
-  /* padding-bottom: 2%; */     /* frm: commented out for new map layout UI */
   background-color: #232444;
-  /* max-width: 300px; */       /* frm: commented out for new map layout UI */
-  /* width: 32%; */             /* frm: commented out for new map layout UI */
-  /* position: fixed; */        /* frm: commented out for new map layout UI */
-  /* left: 2%; */               /* frm: commented out for new map layout UI */
-  /* top: 2%; */                /* frm: commented out for new map layout UI */
   z-index:11;                   /* frm: not sure we need z-index anymore */
-  box-shadow: 10px 0px 5px rgba(0, 0, 0, .3);   /* frm: don't need bottom shadow for new map layout UI */
-
+  box-shadow: 10px 0px 5px rgba(0, 0, 0, .3);   
 }
 
-/* frm: Added class, desktopSearch, as an analog for the preexisting mobileSearch
- *      so that I could have a different layout (using grid) for the deesktop
- *      use case.  In this case the search bar has two rows that take up all 
- *      of the vertical space.
- */
-
 .desktopSearch {
-  /* For desktop, we want two rows */
-  height: 100vh;                        /* frm: added for new map layout UI */
-  display: grid;                        /* frm: added for new map layout UI */
-  grid-template-rows: auto auto;        /* frm: added for new map layout UI */
-  grid-gap: 0;                          /* frm: added for new map layout UI */
+  /* For desktop, we want two rows: 1) search criteria and 2) the scrolling list of events */
+  height: 100vh;                        
+  display: grid;                        
+  grid-template-rows: auto auto;        
+  grid-gap: 0;                          
 }
 
 .mobileSearch {
@@ -193,7 +165,7 @@ html, body, #root, .app {
   align-items: flex-end;
   justify-content: center;
   padding-left: 5%;
-  padding-right: 5%;    /* frm: changed from 7% to 5% */
+  padding-right: 5%;    
   padding-top: 5%;
   padding-bottom: 5%;
 
@@ -294,7 +266,7 @@ html, body, #root, .app {
   font-size: 16px;
   background-color: #f5f5f5;
   border: none;
-  padding: 0px 5px 0px 5px;    /* frm: changed right-pad from 20px to 5px */
+  padding: 0px 5px 0px 5px;    
   appearance: none;
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -342,7 +314,6 @@ html, body, #root, .app {
 
 .eventList{
   background-color: white;
-  /* height: 500px; */          /* frm: commented out for new map layout UI */
   overflow:hidden;
   overflow-y:scroll;
   margin-bottom: 0px;
@@ -403,26 +374,22 @@ html, body, #root, .app {
 
 .mobileList{
   margin: none;
-  font-size:calc(10px + 1vw);   /* frm: changed from 12px to 10px to conserve whitespace */
+  font-size:calc(10px + 1vw);   
   touch-action: manipulation;
-  position: relative;           /* frm: added so children can be positioned absolutely */
+
   .eventCard{
 
     text-decoration: none;
     color: #232444;
-    /* position: fixed; */      /* frm: commented out for new map layout UI */
     z-index: 10;
-    bottom: 10%;        /* changed from 13% to 10% */
+    bottom: 10%;        
     background-color: white;
-    width: 90%;
     left: 5%;
     max-height: 30vh;
-    min-height: 10vh;  /* changed from 20vh to 10vh to conserve whitespace */
-    box-shadow: 1px 2px 5px rgba(0, 0, 0, .3);
-    /* border: 1px solid #232444; */ /* frm: removed as part of new layout UI */
+    min-height: 10vh;  
 
     h3{
-      margin-top: 10px;  /* frm: smaller for mobile to conserve whitespace */
+      margin-top: 10px;  
       margin-bottom: 10px;
       text-transform: uppercase;
     }
@@ -432,45 +399,47 @@ html, body, #root, .app {
     }
 
     .mobileInfo{
-
       padding-left: 5%;
       padding-right: 5%;
       padding-bottom: 1%;
 
       .eventRSVP{
-        display: none;  /* frm: changed from visibility: hidden to display: none to conserve whitespace */
-        text-align: right;
+        display: none;  
       }
 
     }
   }
 
+  .mobileNavWrapper {     /* contains navigation buttons (next/prev) and Info/RSVP button */
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+  }
+
   button{
-    /* position: absolute; */         /* frm: changed for new map layout UI */
-    bottom: 3%;         /* frm: changed from 5% to 3% */
+    bottom: 3%;         
     z-index: 10;
     background-color: #232444;
     border: none;
     color: white;
-    font-size: 16px;    /* frm: changed from 24px */
-    height: 30px;       /* frm: changed from 40px to 30px */
-    box-shadow: 1px 2px 5px rgba(0, 0, 0, .3);
+    font-size: 16px;    
+    height: 30px;       
 
   }
   #mobileRSVP{
-    /* left: 35%; */ /* frm: commented out trying to get flex to work */
-    /* width: 30vw; */ /* frm: commented out because I now have it flex its width */
-    flex: 1;
+    flex: 1;            /* Info/RSVP button stretches to use up all available space */
     a{
       text-decoration: none;
       color:white;
     }
   }
   #leftIndex{
-    /* left: 25px; */ /* frm: commented out trying to get flex to work */
+    width: 50px;
+    border-right: 3px solid white;      /* separate nav button from RSVP/Info button */
   }
   #rightIndex{
-    /* right: 25px; */ /* frm: commented out trying to get flex to work */
+    width: 50px;
+    border-left: 3px solid white;       /* separate nav button from RSVP/Info button */
   }
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -438,7 +438,7 @@ html, body, #root, .app {
     background-color: #232444;
     border: none;
     color: white;
-    font-size: 24px;
+    font-size: 16px;    /* frm: changed from 24px */
     height: 30px;       /* frm: changed from 40px to 30px */
     box-shadow: 1px 2px 5px rgba(0, 0, 0, .3);
 

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -77,7 +77,7 @@ export function EventList(props) {
       }
     })
 
-    //Location filter
+    //Location filter: if user has clicked on a marker, then only show that one event
     if(props.locFilt != null){
       if(eventHasValidLocation(event)) {
         if(event['location']['location']['latitude'] !== props.locFilt['lat'] || event['location']['location']['longitude'] !== props.locFilt['lng']){

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -50,17 +50,6 @@ function EventTimes(props) {
   }
 }
 
-/*
- *
- * ??? frm: DELETE this once I have verified that Util().eventHasValidLocation() works
- *
-function eventHasValidLocation(event) {
-  // Utility function to avoid repeating this logic...
-  return ('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']);
-}
- *
- */
-
 export function EventList(props) {
   let listEvents;
   if(props.events.length > 0){
@@ -116,7 +105,7 @@ export function EventList(props) {
   listEvents = null;
 }
 
-  // frm: At this point listEvents is either null or the HTML for a list of each of the events
+  // At this point listEvents is either null or the HTML for a list of each of the events
 
   return (
     <ul className="eventList">{listEvents}

--- a/src/Map.js
+++ b/src/Map.js
@@ -159,8 +159,8 @@ export function Map(props){
 
   		}
 
-      // zoom to marker bounds, plus padding (percentage)
-      map.current.fitBounds(markers.current.getBounds().pad(0.1));  /* frm: messing with pad */
+      // zoom to marker bounds, plus padding to make sure entire marker is visible
+      map.current.fitBounds(markers.current.getBounds().pad(0.1));
     }
   }, [locations, props.hoverMarker, props.locFilt]);
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -159,7 +159,30 @@ export function Map(props){
 
   		}
 
+      /* ??? frm: The current code immediately below does not correctly resize and
+       *          rezoom on mobile.  The problem is that the amount of space used
+       *          for each card varies, and hence the amount of space available
+       *          for the map can change every time the cardIndex changes.
+       *          
+       *          The code below tells the map to resize (by calling invlidatesize() )
+       *          everytime the hoverMarker changes which is almost correct.  Instead
+       *          it should resize every time the cardIndex changes.  
+       *    
+       *          Unfortuately, the Map currently does not know about the cardIndex
+       *          It would be easy to pass it in the way the hoverMarker is currently
+       *          passed in, but I want to wait and make that change in a separate
+       *          pull request (there is another related issue/bug concerning hoverMarker
+       *          on mobile that I will change at the same time).
+       *
+       *          I am also not going to create an issue for this on github yet
+       *          because this is not a problem in the old UI - so it doesn't make
+       *          sense to create an issue that is not yet a problem in production.
+       *          I will create an issue once the new tiled layout is merged...
+       */
+
       // zoom to marker bounds, plus padding to make sure entire marker is visible
+      // ??? frm: probably only have to invalidateSize() on mobile... (but it is a cheap op)
+      map.current.invalidateSize();  // make sure the map fits its allocated space (mobile issue)
       map.current.fitBounds(markers.current.getBounds().pad(0.1));
     }
   }, [locations, props.hoverMarker, props.locFilt]);

--- a/src/Map.js
+++ b/src/Map.js
@@ -145,6 +145,17 @@ export function Map(props){
 
         if(key === props.hoverMarker || (props.locFilt !== null && key === props.locFilt['lat'] + "&" + props.locFilt['lng'])){
           console.log("matching");
+          // frm: Start of Debugging
+              if(key === props.hoverMarker) {
+                  console.log("matched hover: " + props.hoverMarker);
+              }
+              
+              if(props.locFilt !== null && key === props.locFilt['lat'] + "&" + props.locFilt['lng']){
+                  let thisLat = props.locFilt['lat'];
+                  let thisLng = props.locFilt['lng'];
+                  console.log("matched locFilt: lat = " + thisLat + ", long = " + thisLng);
+              }
+          // frm: End of Debugging
           highlighted = true;
         }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -160,7 +160,7 @@ export function Map(props){
   		}
 
       // zoom to marker bounds, plus padding (percentage)
-      map.current.fitBounds(markers.current.getBounds().pad(0.01));  /* frm: messing with pad */
+      map.current.fitBounds(markers.current.getBounds().pad(0.1));  /* frm: messing with pad */
     }
   }, [locations, props.hoverMarker, props.locFilt]);
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -39,7 +39,7 @@ export function Map(props){
               	zoom = map.getZoom(),
               	delta = this._delta,
               	normalizedDelta = 0,
-              	snap = this._map.options.zoomSnap || 0;
+              	snap = this._map.options.zoomSnap || 0;  // ??? frm: why use this._map instead of just map
             
     		  wheelDeltaList.push(Math.abs(delta));
     		  var average = 0;
@@ -59,7 +59,7 @@ export function Map(props){
             
     		  var deltaTime = currentScrollTime - lastScroll;
             
-    		  var d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4),
+    		  var d2 = this._delta / (this._map.options.wheelPxPerZoomLevel * 4),  // ??? frm: why use this._map instead of just map
     		  d3 = 4 * Math.log(2 / (1 + Math.exp(-Math.abs(d2)))) / Math.LN2,
     		  d4 = snap ? Math.ceil(d3 / snap) * snap : d3,
                     normalizedDelta = map._limitZoom(zoom + (this._delta > 0 ? d4 : -d4)) - zoom;
@@ -196,7 +196,14 @@ export function Map(props){
             const lat = props.events[first]['location']['location']['latitude'];
             const long = props.events[first]['location']['location']['longitude'];
 
-            if(center[0] !== lat || center[0] !== long){
+            /* 
+             * If "first" non-private location is different from previous "center"
+             * then update the "center".  This will center the map view on the 
+             * "first" non-private location which we assume is the one closest to
+             * the given zip code (the Mobilize API should return events in the 
+             * order of closest first)
+             */
+            if(center[0] !== lat || center[1] !== long){  
               setCenter([lat, long]);
               setNewCenter(true);
             }

--- a/src/Map.js
+++ b/src/Map.js
@@ -145,17 +145,6 @@ export function Map(props){
 
         if(key === props.hoverMarker || (props.locFilt !== null && key === props.locFilt['lat'] + "&" + props.locFilt['lng'])){
           console.log("matching");
-          // frm: Start of Debugging
-              if(key === props.hoverMarker) {
-                  console.log("matched hover: " + props.hoverMarker);
-              }
-              
-              if(props.locFilt !== null && key === props.locFilt['lat'] + "&" + props.locFilt['lng']){
-                  let thisLat = props.locFilt['lat'];
-                  let thisLng = props.locFilt['lng'];
-                  console.log("matched locFilt: lat = " + thisLat + ", long = " + thisLng);
-              }
-          // frm: End of Debugging
           highlighted = true;
         }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -160,7 +160,7 @@ export function Map(props){
   		}
 
       // zoom to marker bounds, plus padding (percentage)
-      map.current.fitBounds(markers.current.getBounds().pad(0.5));
+      map.current.fitBounds(markers.current.getBounds().pad(0.1));
     }
   }, [locations, props.hoverMarker, props.locFilt]);
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -160,7 +160,7 @@ export function Map(props){
   		}
 
       // zoom to marker bounds, plus padding (percentage)
-      map.current.fitBounds(markers.current.getBounds().pad(0.1));
+      map.current.fitBounds(markers.current.getBounds().pad(0.01));  /* frm: messing with pad */
     }
   }, [locations, props.hoverMarker, props.locFilt]);
 

--- a/src/MobileList.js
+++ b/src/MobileList.js
@@ -102,6 +102,13 @@ export function MobileList(props){
       })
 
       return (
+        /*
+         * frm: Original code that made the event text be an anchor tag.
+         *
+         *      I changed this because with the new layout, the next and previous buttons
+         *      are right next to the event text, making it too easy to mistakenly 
+         *      activate the anchor instead of just going to next/previous event.
+         *
         <a href={event['browser_url']}
           className="eventCard"
           target="_blank"
@@ -116,8 +123,24 @@ export function MobileList(props){
             <EventTimes rawTimes={rawTimes} />
             <p className="eventRSVP">Click to RSVP</p>
           </div>
-
         </a>
+         *
+         */
+
+        <div 
+          className="eventCard"
+          key={event['id']}
+          coord={('location' in event && 'location' in event['location'] && 'latitude' in event['location']['location']) ? "" + event['location']['location']['latitude'] + "&" + event['location']['location']['longitude'] : ""}
+          onMouseEnter={(event) => { props.updatedHover(event['currentTarget'].getAttribute('coord')) }}
+          onMouseLeave={(event) => { props.updatedHover(null) }}>
+          <div className="mobileInfo">
+            <h3>{event['title']}</h3>
+            <p><strong>{event['location']['venue']}</strong> in <strong>{event['location']['locality']}</strong></p>
+            <EventTimes rawTimes={rawTimes} />
+            <p className="eventRSVP">Click to RSVP</p>
+          </div>
+
+        </div>
 
       )
     }).filter((arrItem) => {
@@ -145,7 +168,7 @@ export function MobileList(props){
           props.cardIndex > 0 &&
           <button id="leftIndex" onClick={() => props.updateCardIndex(props.cardIndex-1)}>← </button>
         }
-        <button id="mobileRSVP"><a href={props.events[props.cardIndex]['browser_url']} target="_blank" rel="noopener">RSVP</a></button>
+        <button id="mobileRSVP"><a href={props.events[props.cardIndex]['browser_url']} target="_blank" rel="noopener">Details</a></button>
         {
           props.cardIndex < listEvents.length-1 &&
           <button id="rightIndex" onClick={() => props.updateCardIndex(props.cardIndex+1)}> →</button>

--- a/src/MobileList.js
+++ b/src/MobileList.js
@@ -140,6 +140,7 @@ export function MobileList(props){
     return (
       <div className="mobileList">
         {listEvents[props.cardIndex]}
+        <div className="mobileNavWrapper">
         {
           props.cardIndex > 0 &&
           <button id="leftIndex" onClick={() => props.updateCardIndex(props.cardIndex-1)}>← </button>
@@ -149,6 +150,7 @@ export function MobileList(props){
           props.cardIndex < listEvents.length-1 &&
           <button id="rightIndex" onClick={() => props.updateCardIndex(props.cardIndex+1)}> →</button>
         }
+        </div>
 
       </div>
     );

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -104,7 +104,8 @@ export function SearchBar(props){
    */
 
   return(
-    <div className={(props.events != null ? "searchBar activeList" : "searchBar") + (props.deviceIsMobile ? " mobileSearch" : "")}>
+    /* <div className={(props.events != null ? "searchBar activeList" : "searchBar") + (props.deviceIsMobile ? " mobileSearch" : "")}> */  /* frm: original code */
+    <div className={(props.events != null ? "searchBar activeList" : "searchBar") + (props.deviceIsMobile ? " mobileSearch" : " desktopSearch")}>
       <div className="userInput">
         <form onSubmit={onSubmit} id="zipForm" data-has-input={!!input.length}>
           <label htmlFor="zipInput">ZIP</label>

--- a/src/SearchBar.js
+++ b/src/SearchBar.js
@@ -43,7 +43,9 @@ export function SearchBar(props){
     event.preventDefault();
     props.updateRange(rangeInput);  // calls setCurrRange() in App.js triggering a Mobilize API call and  a re-render
     setZip(input);
-    // ??? frm: Should I add a call to setEventKind() here?
+    /* ??? frm: Should I add a call to setEventKind() here?
+     *          I don't think it necessary until I put the event kind in the URL...
+     */         
   }
 
   function setRange(input){
@@ -104,7 +106,6 @@ export function SearchBar(props){
    */
 
   return(
-    /* <div className={(props.events != null ? "searchBar activeList" : "searchBar") + (props.deviceIsMobile ? " mobileSearch" : "")}> */  /* frm: original code */
     <div className={(props.events != null ? "searchBar activeList" : "searchBar") + (props.deviceIsMobile ? " mobileSearch" : " desktopSearch")}>
       <div className="userInput">
         <form onSubmit={onSubmit} id="zipForm" data-has-input={!!input.length}>


### PR DESCRIPTION
Most of the work in this pull request is to change the overall layout of the app to a tiled design rather than having the search bar and event information appear on top of the map.  Stated differently, the map is now NOT underneath everything else - instead it occupies its own area adjacent to other elements.

The reason for the change is that sometimes map markers ended up underneath other elements and hence were hidden.  There was no simple way for a user to know why no marker was visible.

With a tiled layout, we can ask the map to zoom in to make all markers visible which maximizes the map screen real estate.

Architecturally, the biggest change is that I introduced some new CSS classes to distinguish between desktop and mobile (the layouts are different), and I used CSS "grid" for the high level layout.

I am open to any and all suggestions/opinions.

Lastly note that I have left some comments behind about work I intend to do after this work has been merged.  I decided it was best to leave those changes as separate bits of work, but I also wanted to leave tracks so that I could easily find where changes need to be made later.  Stated differently, please don't get too pissed off about my forward looking comments - I will clean them up soon after this gets merged.

Thanks,

-Fred