### PR TITLE
Fix for Issue #59 - mobile marker stays highlighted after "click"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -36,8 +36,7 @@ const queryString = require('query-string');
  * 
  */
 
-// const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
-const deviceIsMobile = true;
+const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
 
 function App() {
 

--- a/src/App.js
+++ b/src/App.js
@@ -36,7 +36,8 @@ const queryString = require('query-string');
  * 
  */
 
-const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+// const deviceIsMobile = isMobile;        // HACK to allow easy mocking of isMobile for testing/debugging
+const deviceIsMobile = true;
 
 function App() {
 
@@ -144,7 +145,14 @@ function App() {
       }
       <Map currZip={currZip} events={filteredEvents} hoverMarker={hoverEvent} selectLoc={(newLoc) => setLocFilt(newLoc)} locFilt={locFilt}/>
       {filteredEvents !== null && deviceIsMobile &&
-        <MobileList events={filteredEvents} updatedHover={(newHover) => setHoverEvent(newHover)} locFilt={locFilt} cardIndex={cardIndex} updateCardIndex={(update) => setCardIndex(update)}/>
+        <MobileList 
+          events={filteredEvents} 
+          updatedHover={(newHover) => setHoverEvent(newHover)} 
+          locFilt={locFilt} 
+          selectLoc={(newLoc) => setLocFilt(newLoc)} 
+          cardIndex={cardIndex} 
+          updateCardIndex={(update) => setCardIndex(update)} 
+          />
       }
     </div>
   );

--- a/src/EventList.js
+++ b/src/EventList.js
@@ -66,14 +66,14 @@ export function EventList(props) {
       }
     })
 
-    //Location filter: if user has clicked on a marker, then only show that one event
+    //Location filter: if user has clicked on a marker, then only show events at that location
     if(props.locFilt != null){
       if(eventHasValidLocation(event)) {
         if(event['location']['location']['latitude'] !== props.locFilt['lat'] || event['location']['location']['longitude'] !== props.locFilt['lng']){
-          return(null);
+          return(null); // event is not at the location filter's coordinates
         }
       } else {
-        return(null);
+        return(null);   // event is private - no location, hence no marker
       }
     }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -8,7 +8,7 @@ import { eventHasValidLocation } from './Util';
 export function Map(props){
 
   const [center, setCenter] = useState([39.8283, -98.5795]);  // center of the USA
-  const [locations, setLocations] = useState({});
+  const [locations, setLocations] = useState({});       // set of unique lat/longs for events
   const [newCenter, setNewCenter] = useState(false);
   const map = useRef();
   const markers = useRef();
@@ -147,6 +147,8 @@ export function Map(props){
           console.log("matching");
           highlighted = true;
         }
+        
+
 
   			let cord = key.split("&");
 
@@ -199,16 +201,7 @@ export function Map(props){
         // Find out whether there are any events in the list that are not private
         let first = -1;  
         for (let i=0; i<props.events.length; i++) {
-            if (eventHasValidLocation(props.events[i])
-              /*
-               *
-              ('location' in props.events[i]) && 
-              ('location' in props.events[i]['location']) && 
-              ('latitude' in props.events[i]['location']['location'])
-               *
-               */
-            ) 
-            {
+            if (eventHasValidLocation(props.events[i])) {
               first = i;
               break;
             }

--- a/src/MobileList.js
+++ b/src/MobileList.js
@@ -49,6 +49,35 @@ function EventTimes(props) {
   }
 }
 
+
+/*
+ * Utility functions for the actions for the "previous" and "next" buttons.
+ * In each case we want to decrement/increment the cardIndex so that the 
+ * app will show the previoius/next event.  But we also want to make sure
+ * that the location filter (locFilt in App.js) is reset to null since
+ * if we change the current event, we may move to a new location (lat/long)
+ * and we do not want the map to continue to highlight the old locFilt
+ * location (lat/long).
+ */
+
+function clickPrevious(props) {
+    if (!(props.cardIndex > 0)) { // verify that there is indeed a previous event
+        console.warn("clickPrevious: cardIndex is not > 0");
+        return;
+    }
+    props.updateCardIndex(props.cardIndex-1);
+    props.selectLoc(null);
+}
+
+function clickNext(props, listEvents) {
+    if (!(props.cardIndex < listEvents.length-1)) {  // verify that there is a next event
+        console.warn("clickNext: cardIndex is too large");
+        return;
+    }
+    props.updateCardIndex(props.cardIndex+1);
+    props.selectLoc(null);
+}
+
 export function MobileList(props){
 
   //Mobile's location filter doesn't filter but moves the currentIndex to the location's first event
@@ -166,12 +195,12 @@ export function MobileList(props){
         <div className="mobileNavWrapper">
         {
           props.cardIndex > 0 &&
-          <button id="leftIndex" onClick={() => props.updateCardIndex(props.cardIndex-1)}>← </button>
+          <button id="leftIndex" onClick={() => clickPrevious(props)}>← </button>
         }
         <button id="mobileRSVP"><a href={props.events[props.cardIndex]['browser_url']} target="_blank" rel="noopener">Details</a></button>
         {
           props.cardIndex < listEvents.length-1 &&
-          <button id="rightIndex" onClick={() => props.updateCardIndex(props.cardIndex+1)}> →</button>
+          <button id="rightIndex" onClick={() => clickNext(props, listEvents)}> →</button>
         }
         </div>
 


### PR DESCRIPTION
This is a fix for Issue #59 

The bug's behavior was that if the user clicked on a marker and then used the "previous" or "next" button, the clicked on marker would remain highlighted in addition to the new event's marker.  This was because the click event did not reset locFilt (the variable that records the lat/long when a user clicks on the map).  On mobile this needs to be cleared when the user clicks "previous" or "next".

The fix entailed sending in as part of the "props" the function to update locFilt to MobileList and to then call that function when the user clicks "previous" or "next".

There are a couple of other cosmetic changes...